### PR TITLE
Provide guidance for version condition usage

### DIFF
--- a/nerves-hub/setup/deployments.md
+++ b/nerves-hub/setup/deployments.md
@@ -24,13 +24,13 @@ mix nerves_hub.deployment create
 NervesHub organization: nerveshub
 Deployment name: qa_deployment
 firmware uuid: 1cbecdbb-aa7d-5aee-4ba2-864d518417df
-version condition:
+version condition: < 0.3.0
 tags: qa
 Local user password:
 Deployment test created
 ```
 
-Here we create a new deployment called `qa_deployment`. In the conditions of this deployment we left the `version condition` unspecified and the `tags` set to only `qa`. This means that in order for a device to qualify for an update, it needs to have at least the tags `[qa]` and the device can be coming from any version.
+Here we create a new deployment called `qa_deployment`. In the conditions of this deployment, we specify "< 0.3.0" and the `tags` set to only `qa`. This means that in order for a device to qualify for an update, it needs to have at least the tags `[qa]` and the device must not already have been updated to this version.
 
 At this point we can try to update the connected device.
 

--- a/nerves-key/integration-with-nerveshub.md
+++ b/nerves-key/integration-with-nerveshub.md
@@ -22,7 +22,7 @@ Device 123456789ABCDE created
 ```
 
 {% hint style="info" %}
-When registering devices in bulk, we've found that there's usually a convenient hook in the manufacturing process to call `mix nerves_hub.device create` with commandline parameters. A future enhancement to NervesHub will allows you to have NervesHub automatically create devices that present properly signed device certificates and firmware metadata.
+When registering devices in bulk, we've found that there's usually a convenient hook in the manufacturing process to call `mix nerves_hub.device create` with commandline parameters. A future enhancement to NervesHub will allow you to have NervesHub automatically create devices that present properly signed device certificates and firmware metadata.
 {% endhint %}
 
 ### Integration with your Nerves project

--- a/nerves-key/nerves-integration.md
+++ b/nerves-key/nerves-integration.md
@@ -1,6 +1,6 @@
 # Nerves integration
 
-Nerves can use the serial number programmed into the NervesKey for the hostname. This can come in handy for finding devices on the network since the hostname can be reported via DHCP or broadcast using mDNS. 
+Nerves can use the serial number programmed into the NervesKey for the hostname. This can come in handy for finding devices on the network, since the hostname can be reported via DHCP or broadcast using mDNS. 
 
 {% hint style="info" %}
 The DHCP client for Nerves reports hostnames to the DHCP server. Some DHCP servers like dnsmasq-based ones register those names with a colocated DNS server so that requests of that name return the IP address of the Nerves-based device. Many DHCP servers do not do this, so mDNS is the only option for easily finding the device.


### PR DESCRIPTION
At present, if no tag condition is provided, the device can fall
into a loop where it always matches a need to update.