### PR TITLE
Add docs for first time setup

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -1,44 +1,51 @@
 # Table of contents
 
-* [Introduction](README.md)
-* [High level architecture](high-level-architecture.md)
-* [Public key infrastructure](public-key-infrastructure.md)
-* [Terminology](terminology.md)
+- [Introduction](README.md)
+- [High level architecture](high-level-architecture.md)
+- [Public key infrastructure](public-key-infrastructure.md)
+- [Terminology](terminology.md)
 
 ## Nerves Hub
 
-* [Setup](nerves-hub/setup/README.md)
-  * [Creating an account](nerves-hub/setup/creating-an-account.md)
-  * [Add NervesHub to your project](nerves-hub/setup/adding-nerveshub-to-your-project.md)
-  * [Firmware signing keys](nerves-hub/setup/firmware-signing-keys.md)
-  * [Products](nerves-hub/setup/nerveshub-products.md)
-  * [Devices](nerves-hub/setup/devices.md)
-  * [Firmware](nerves-hub/setup/firmware.md)
-  * [Deployments](nerves-hub/setup/deployments.md)
-* [Managing organizations and products](nerves-hub/managing-organizations-and-products.md)
-* [Device management](nerves-hub/device-management.md)
+- [Setup](nerves-hub/setup/README.md)
+  - [Creating an account](nerves-hub/setup/creating-an-account.md)
+  - [Add NervesHub to your project](nerves-hub/setup/adding-nerveshub-to-your-project.md)
+  - [Firmware signing keys](nerves-hub/setup/firmware-signing-keys.md)
+  - [Products](nerves-hub/setup/nerveshub-products.md)
+  - [Devices](nerves-hub/setup/devices.md)
+  - [Firmware](nerves-hub/setup/firmware.md)
+  - [Deployments](nerves-hub/setup/deployments.md)
+- [Managing organizations and products](nerves-hub/managing-organizations-and-products.md)
+- [Device management](nerves-hub/device-management.md)
+- [Custom Deployment](nerves-hub/custom-deployment/README.md)
+  - [Requirements](nerves-hub/custom-deployment/requirements.md)
+  - [Configure DNS](nerves-hub/custom-deployment/configure-dns.md)
+  - [Configure SES](nerves-hub/custom-deployment/configure-ses.md)
+  - [Create tfvars](nerves-hub/custom-deployment/create-tfvars.md)
+  - [Configure Certificates](nerves-hub/custom-deployment/configure-certificates.md)
+  - [Run Terraform](nerves-hub/custom-deployment/run-terraform.md)
+  - [Run Migrations](nerves-hub/custom-deployment/run-migrations.md)
 
 ## Nerves Key
 
-* [Introduction](nerves-key/introduction.md)
-* [NervesKey for Raspberry Pi](nerves-key/getting-started.md)
-* [Private keys and certificates](nerves-key/private-key-storage.md)
-* [General NervesKey storage](nerves-key/general-nerveskey-storage.md)
-* [Quickstart](nerves-key/provisioning.md)
-* [Provisioning in Elixir](nerves-key/provisioning-in-elixir.md)
-* [Nerves integration](nerves-key/nerves-integration.md)
-* [NervesHubLink integration](nerves-key/integration-with-nerveshublink.md)
-* [MQTT integration](nerves-key/mqtt-integration.md)
+- [Introduction](nerves-key/introduction.md)
+- [NervesKey for Raspberry Pi](nerves-key/getting-started.md)
+- [Private keys and certificates](nerves-key/private-key-storage.md)
+- [General NervesKey storage](nerves-key/general-nerveskey-storage.md)
+- [Quickstart](nerves-key/provisioning.md)
+- [Provisioning in Elixir](nerves-key/provisioning-in-elixir.md)
+- [Nerves integration](nerves-key/nerves-integration.md)
+- [NervesHubLink integration](nerves-key/integration-with-nerveshublink.md)
+- [MQTT integration](nerves-key/mqtt-integration.md)
 
 ## User API
 
-* [Users](user-api/users.md)
-* [Firmware Signing Keys](user-api/firmware-signing-keys.md)
-* [FAQ](user-api/faq.md)
+- [Users](user-api/users.md)
+- [Firmware Signing Keys](user-api/firmware-signing-keys.md)
+- [FAQ](user-api/faq.md)
 
 ## Device API
 
-* [Overview](device-api/overview.md)
-* [Phoenix Channel](device-api/phoenix-channel.md)
-* [HTTP Endpoint](device-api/http-endpoint.md)
-
+- [Overview](device-api/overview.md)
+- [Phoenix Channel](device-api/phoenix-channel.md)
+- [HTTP Endpoint](device-api/http-endpoint.md)

--- a/nerves-hub/custom-deployment/README.md
+++ b/nerves-hub/custom-deployment/README.md
@@ -1,0 +1,5 @@
+# Custom Deployment
+
+### Getting Started
+
+The following sections will walk you through deploying your own instance(s) of NervesHub in [AWS](https://aws.amazon.com/what-is-aws/). Currently only AWS is supported via the [NervesHub Terraform](https://github.com/nerves-hub/terraform) infrastructure but this could be adapted to support the cloud services provider of your choice.

--- a/nerves-hub/custom-deployment/configure-certificates.md
+++ b/nerves-hub/custom-deployment/configure-certificates.md
@@ -1,6 +1,6 @@
 # Configure Certificates
 
-The NervesHub Certificate Authority is used to generate certificates for representing trusted device connections to the NervesHub API. This app needs an initial certificate chain in order to properly operate. Clone the nerves_hub_ca repo and run the following command to generate the required certificates:
+The NervesHub Certificate Authority is used to generate certificates for representing trusted device connections to the NervesHub API. This app needs an initial certificate chain in order to properly operate. Clone the [`nerves_hub_ca`](https://github.com/nerves-hub/nerves_hub_ca) repo and run the following command to generate the required certificates:
 
 ```bash
 mix nerves_hub_ca.init --path path/to/nerveshub-terraform/ssl/(staging | production)

--- a/nerves-hub/custom-deployment/configure-certificates.md
+++ b/nerves-hub/custom-deployment/configure-certificates.md
@@ -1,0 +1,9 @@
+# Configure Certificates
+
+The NervesHub Certificate Authority is used to generate certificates for representing trusted device connections to the NervesHub API. This app needs an initial certificate chain in order to properly operate. Clone the nerves_hub_ca repo and run the following command to generate the required certificates:
+
+```bash
+mix nerves_hub_ca.init --path path/to/nerveshub-terraform/ssl/(staging | production)
+```
+
+Specify the staging or production directory for whichever environment you are generating certificates.

--- a/nerves-hub/custom-deployment/configure-dns.md
+++ b/nerves-hub/custom-deployment/configure-dns.md
@@ -2,6 +2,6 @@
 
 First, you will need to manually add a hosted zone to [Route 53](https://aws.amazon.com/route53/) for the domain at which you wish to run nerves hub. You do not need to have the domain registered in Route 53, but you will need to be able to point the domain to the Route 53 nameservers.
 
-If you plan on running both staging and production environments, you will need to configure a second hosted zone with a staging subdomain to the production domain e.g. `staging.domain.com`. Then you will need to add and NS record to the hosted zone for the production domain with the nameservers that were generated for the staging hosted zone.
+If you plan on running both staging and production environments, you will need to configure a second hosted zone with a staging subdomain to the production domain e.g. `staging.domain.com`. Then you will need to add an NS record to the hosted zone for the production domain with the nameservers that were generated for the staging hosted zone.
 
 Finally, use [Certificate Manager](https://aws.amazon.com/certificate-manager/) to request public certificates for the `www` subdomain of each of your newly created hosted zones. e.g. `www.domain.com`, `www.staging.domain.com`. Follow the Certificat Manager instructions to validate via DNS or email and wait for the certificates to be issued.

--- a/nerves-hub/custom-deployment/configure-dns.md
+++ b/nerves-hub/custom-deployment/configure-dns.md
@@ -1,0 +1,7 @@
+# Configure DNS
+
+First, you will need to manually add a hosted zone to [Route 53](https://aws.amazon.com/route53/) for the domain at which you wish to run nerves hub. You do not need to have the domain registered in Route 53, but you will need to be able to point the domain to the Route 53 nameservers.
+
+If you plan on running both staging and production environments, you will need to configure a second hosted zone with a staging subdomain to the production domain e.g. `staging.domain.com`. Then you will need to add and NS record to the hosted zone for the production domain with the nameservers that were generated for the staging hosted zone.
+
+Finally, use [Certificate Manager](https://aws.amazon.com/certificate-manager/) to request public certificates for the `www` subdomain of each of your newly created hosted zones. e.g. `www.domain.com`, `www.staging.domain.com`. Follow the Certificat Manager instructions to validate via DNS or email and wait for the certificates to be issued.

--- a/nerves-hub/custom-deployment/configure-ses.md
+++ b/nerves-hub/custom-deployment/configure-ses.md
@@ -1,3 +1,5 @@
 # Configure [SES](https://aws.amazon.com/ses/)
 
 In the SES console select the `SMTP Settings` option from the left hand menu. Click the blue `Create My SMTP Credentials` button proceed through the creation steps, taking note of the Access Key ID and the Secret Access Key that will be generated for the SMTP user.
+
+By default the SES service will be sandboxed by AWS. This means that only certain AWS emails are valid unless explicity verified. You will need to configure the SES service to work with your target domains before emailing will be fully functional.

--- a/nerves-hub/custom-deployment/configure-ses.md
+++ b/nerves-hub/custom-deployment/configure-ses.md
@@ -1,0 +1,3 @@
+# Configure [SES](https://aws.amazon.com/ses/)
+
+In the SES console select the `SMTP Settings` option from the left hand menu. Click the blue `Create My SMTP Credentials` button proceed through the creation steps, taking note of the Access Key ID and the Secret Access Key that will be generated for the SMTP user.

--- a/nerves-hub/custom-deployment/create-tfvars.md
+++ b/nerves-hub/custom-deployment/create-tfvars.md
@@ -1,12 +1,12 @@
 # Create a tfvars file
 
-Before you can deploy the architecture with Terraform you will need to set the variables that Terraform will use to generate the AWS services. First, You will need to clone and change directory to the the NervesHub Terraform repo. From there you can copy the example tfvars file:
+Before you can deploy the architecture with Terraform you will need to set the variables that Terraform will use to generate the AWS services. First, You will need to clone and change directory to the the [NervesHub Terraform repo](https://github.com/nerves-hub/terraform). From there you can copy the example tfvars file:
 
 ```bash
  cp terraform.tfvars.example terraform.tfvars
 ```
 
-If you haven't done so yet, you will need to configure your AWS credentials so that the AWS CLI tool can access AWS. Please the note the associated profile name. Finally, fill out the variables in the newly created `terraform.tfvars` with the data that will best support your instance of NervesHub. Below is a brief description of required or important variables and suggested values:
+If you haven't done so yet, you will need to configure your AWS credentials so that the AWS CLI tool can access AWS. Please note the associated profile name. Finally, fill out the variables in the newly created `terraform.tfvars` with the data that will best support your instance of NervesHub. Below is a brief description of required or important variables and suggested values:
 
 - `aws_region` = the region to which you want the app deployed e.g. `us-east-1`
 - `aws_profile` = the profile from your AWS credentials file that will grant Terraform access to AWS

--- a/nerves-hub/custom-deployment/create-tfvars.md
+++ b/nerves-hub/custom-deployment/create-tfvars.md
@@ -1,0 +1,30 @@
+# Create a tfvars file
+
+Before you can deploy the architecture with Terraform you will need to set the variables that Terraform will use to generate the AWS services. First, You will need to clone and change directory to the the NervesHub Terraform repo. From there you can copy the example tfvars file:
+
+```bash
+ cp terraform.tfvars.example terraform.tfvars
+```
+
+If you haven't done so yet, you will need to configure your AWS credentials so that the AWS CLI tool can access AWS. Please the note the associated profile name. Finally, fill out the variables in the newly created `terraform.tfvars` with the data that will best support your instance of NervesHub. Below is a brief description of required or important variables and suggested values:
+
+- `aws_region` = the region to which you want the app deployed e.g. `us-east-1`
+- `aws_profile` = the profile from your AWS credentials file that will grant Terraform access to AWS
+- `bucket` = an [S3 bucket](https://aws.amazon.com/s3/) for storing the Terraform state files
+- `dynamodb_table` = a [dynamodb table](https://aws.amazon.com/dynamodb/) for locking the Terraform state
+- `key` = name for the Terraform state file e.g. `terraform.tfstate`
+- `operators` = a list of IAM users
+- `db_username` = name for db user
+- `db_password` = securely generated random string password for the DB
+- `domain` = the domain matching the production hosted zone created in the [configure DNS step](configure-dns.md)
+- `web_secret_key_base` = securely generated random string (e.g. `mix phx.gen.secret`)
+- `web_smtp_username` = the Access Key ID saved from the [configure SES step](configure-ses.md)
+- `web_smtp_password` = the Secret Access Key from the [configure SES step](configure-ses.md)
+- `bucket_prefix` = the prefix for all S3 buckets that will be generated
+- `erl_cookie` = securely generated random string (e.g. `mix phx.gen.secret`)
+- `www_live_view_signing_salt` = securely generated random string (e.g. `mix phx.gen.secret 32`)
+- `ca_image` = docker repo for nerves_hub_ca e.g. `nerveshub/nerves_hub_ca:latest`
+- `www_image` = docker repo for nerves_hub_www e.g. `nerveshub/nerves_hub_www:latest`
+- `device_image` = docker repo for nerves_hub_device e.g. `nerveshub/nerves_hub_device:latest`
+- `api_image` = docker repo for nerves_hub_api e.g. `nerveshub/nerves_hub_api:latest`
+- `whitelist` = a list of IP addresses that can access the site (optional, usually used for a staging environment)

--- a/nerves-hub/custom-deployment/requirements.md
+++ b/nerves-hub/custom-deployment/requirements.md
@@ -1,0 +1,26 @@
+# Requirements
+
+### Repos
+
+The follow git repos will be needed to deploy the infrastructure and run initial database migrations:
+
+- [NervesHub Terraform](https://github.com/nerves-hub/terraform)
+- [NervesHub Web](https://github.com/nerves-hub/nerves_hub_web)
+- [NervesHub CA](https://github.com/nerves-hub/nerves_hub_ca)
+
+### Docker Images
+
+The infrastructure uses [ECS](https://aws.amazon.com/ecs/) to deploy docker images of the four critical parts of the application. You can create your own docker images or use the ones available in Docker Hub:
+
+- [api](https://hub.docker.com/layers/nerveshub/nerves_hub_api/latest/images/sha256-1bed6ac9343da9b4cebbdc509baa2f5090329397d38acd8892e17b33bde694bb)
+- [ca](https://hub.docker.com/layers/nerveshub/nerves_hub_ca/latest/images/sha256-17408ca7c852921d53d66e8e5b08e233d4d1f6e65b7e25947d98880c94c6df03)
+- [device](https://hub.docker.com/layers/nerveshub/nerves_hub_device/latest/images/sha256-011e4168da8ea3654f69dc39e33a4b42456656b6e505c7cc51dca145831231fa)
+- [www](https://hub.docker.com/layers/nerveshub/nerves_hub_www/latest/images/sha256-fad8af8ec5dc4a76c756eb856baff5fd2f262634d5378c70bd5c9da14e132d37)
+
+### Tooling
+
+You will need the following tools installed locally to be able to execute the commands to build and deploy the app.
+
+[AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html)
+[jq](https://stedolan.github.io/jq/download/)
+[Terraform v0.12.24](https://releases.hashicorp.com/terraform/0.12.24/)

--- a/nerves-hub/custom-deployment/run-migrations.md
+++ b/nerves-hub/custom-deployment/run-migrations.md
@@ -1,0 +1,32 @@
+# Run Migrations
+
+The last thing to do is run initial migrations to configure the DB and seed some starter data.
+
+### Default [VPC](https://aws.amazon.com/vpc/)
+
+A brand new AWS account will have a default VPC that has no name value. Our migration scrips will attempt to search VPCs by name and will throw an error if an unnamed VPC is encountered. Please give any unnamed VPCs some default name value.
+
+### Migrate
+
+It's time to run the migration scrips there are two: one in the NervesHub CA repo and one in the NervesHub WWW repo. In the CA repo run:
+
+```bash
+rel/scripts/ecs-migrate.sh nerves-hub-staging nerves-hub-staging nerves-hub-staging-ca nerves-hub-staging-ca-sg
+```
+
+In the WWW repo run:
+
+```bash
+rel/scripts/ecs-migrate.sh nerves-hub-staging nerves-hub-staging nerves-hub-staging-www nerves-hub-staging-web-sg
+```
+
+These scripts may take a few minutes to run and will exit with a 0 status if they are successful.
+
+### Current State
+
+The app should now be totally accessible. The seeded login credentials will be:
+
+```
+username: nerveshub
+password: nerveshub
+```

--- a/nerves-hub/custom-deployment/run-migrations.md
+++ b/nerves-hub/custom-deployment/run-migrations.md
@@ -4,17 +4,17 @@ The last thing to do is run initial migrations to configure the DB and seed some
 
 ### Default [VPC](https://aws.amazon.com/vpc/)
 
-A brand new AWS account will have a default VPC that has no name value. Our migration scrips will attempt to search VPCs by name and will throw an error if an unnamed VPC is encountered. Please give any unnamed VPCs some default name value.
+A brand new AWS account will have a default VPC that has no name value. Our migration scripts will attempt to search VPCs by name and will throw an error if an unnamed VPC is encountered. Please give any unnamed VPCs some default name value.
 
 ### Migrate
 
-It's time to run the migration scrips there are two: one in the NervesHub CA repo and one in the NervesHub WWW repo. In the CA repo run:
+There are 2 migration scripts which need to be run: one in the NervesHub CA repo and one in the NervesHub WWW repo. In the `nerves_hub_ca` repo directory run:
 
 ```bash
 rel/scripts/ecs-migrate.sh nerves-hub-staging nerves-hub-staging nerves-hub-staging-ca nerves-hub-staging-ca-sg
 ```
 
-In the WWW repo run:
+In the `nerves_hub_www` repo directory run:
 
 ```bash
 rel/scripts/ecs-migrate.sh nerves-hub-staging nerves-hub-staging nerves-hub-staging-www nerves-hub-staging-web-sg

--- a/nerves-hub/custom-deployment/run-migrations.md
+++ b/nerves-hub/custom-deployment/run-migrations.md
@@ -30,3 +30,5 @@ The app should now be totally accessible. The seeded login credentials will be:
 username: nerveshub
 password: nerveshub
 ```
+
+For security, it would be a good idea to login and update the default password right away.

--- a/nerves-hub/custom-deployment/run-terraform.md
+++ b/nerves-hub/custom-deployment/run-terraform.md
@@ -1,0 +1,44 @@
+# Run terraform
+
+Now everything should be properly configure and it is time to run the terraform script to stand up the app.
+
+### Create Initial Infrastructure
+
+You can initialize the setup by running `setup.sh`
+
+Answer `yes` to create the initial infrastructure.
+
+```text
+Do you want to perform these actions in workspace "base"?
+  Terraform will perform the actions described above.
+  Only 'yes' will be accepted to approve.
+
+  Enter a value: yes
+```
+
+Answer yes to migrate the state to the remote
+
+```text
+Do you want to migrate all workspaces to "s3"?
+  Both the existing "local" backend and the newly configured "s3" backend
+  support workspaces. When migrating between backends, Terraform will copy
+  all workspaces (with the same names). THIS WILL OVERWRITE any conflicting
+  states in the destination.
+
+  Terraform initialization doesn't currently migrate only select workspaces.
+  If you want to migrate a select number of workspaces, you must manually
+  pull and push those states.
+
+  If you answer "yes", Terraform will migrate all states. If you answer
+  "no", Terraform will abort.
+
+  Enter a value: yes
+```
+
+### Run Application Stack
+
+And now the application stack can be run with the `staging.sh` script. Answer `yes` to any further prompts to grant permission to create resources. After this task completes, the app should be visible at the specified domain.
+
+### Debugging
+
+If the build fails due to services being created out of order and missing dependencies just run the `staging.sh` script again.


### PR DESCRIPTION
Why:

* Nerves hub supports being run privately
* However this option is not well documented

This change addresses the need by:

* Updating the summary markdown with a custom deployment section
* Add content to the custom deployment directory for each step