### PR TITLE
Update instructions for configuring email

### DIFF
--- a/nerves-hub/custom-deployment/configure-ses.md
+++ b/nerves-hub/custom-deployment/configure-ses.md
@@ -2,4 +2,6 @@
 
 In the SES console select the `SMTP Settings` option from the left hand menu. Click the blue `Create My SMTP Credentials` button proceed through the creation steps, taking note of the Access Key ID and the Secret Access Key that will be generated for the SMTP user.
 
-By default the SES service will be sandboxed by AWS. This means that only certain AWS emails are valid unless explicity verified. You will need to configure the SES service to work with your target domains before emailing will be fully functional.
+By default the SES service will be sandboxed by AWS. This means that you will only be able to deliver email to validated or pre-approved AWS addresses. [You may request to be moved out of the SES sandbox](https://docs.aws.amazon.com/ses/latest/DeveloperGuide/request-production-access.html?icmpid=docs_ses_console) in order to send email a wide variety of domains.
+
+Whether or not you choose to remain in the sandbox, you will need validate at least one email address to use as your `from_email` address before you can send any email through SES. In the SES console selec the `Email Addresses` option from the left hand menu. On this screen there should be a blue button prompting you to "Verify a New Email Address". Click on this button to proceed through the validation process. Once your from email address has been validated, please note the address for later configuration use.

--- a/nerves-hub/custom-deployment/create-tfvars.md
+++ b/nerves-hub/custom-deployment/create-tfvars.md
@@ -20,6 +20,7 @@ If you haven't done so yet, you will need to configure your AWS credentials so t
 - `web_secret_key_base` = securely generated random string (e.g. `mix phx.gen.secret`)
 - `web_smtp_username` = the Access Key ID saved from the [configure SES step](configure-ses.md)
 - `web_smtp_password` = the Secret Access Key from the [configure SES step](configure-ses.md)
+- `web_from_email` = the email address from which email will be sent on behalf of the app. [Configured in SES step](configure-ses.md)
 - `bucket_prefix` = the prefix for all S3 buckets that will be generated
 - `erl_cookie` = securely generated random string (e.g. `mix phx.gen.secret`)
 - `www_live_view_signing_salt` = securely generated random string (e.g. `mix phx.gen.secret 32`)


### PR DESCRIPTION
Why:

* We know more detail about how to setup AWS for sending emails

This change addresses the need by:

* Add new info to the configure-ses step
* Add a new var to set on the configure-tfvars step