### PR TITLE
Update outdated information of various kinds

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -12,6 +12,7 @@
 
 ## Nerves Hub
 
+* [Command-line tools](nerves-hub/cli-tools.md)
 * [Setup](nerves-hub/setup/README.md)
   * [Add NervesHub to your project](nerves-hub/setup/adding-nerveshub-to-your-project.md)
   * [Connecting to your environment](nerves-hub/setup/connecting-other-envs.md)
@@ -20,9 +21,6 @@
   * [Devices](nerves-hub/setup/devices.md)
   * [Firmware](nerves-hub/setup/firmware.md)
   * [Deployments](nerves-hub/setup/deployments.md)
-* [Command-line tools](nerves-hub/cli-tools.md)
-* [Managing organizations and products](nerves-hub/managing-organizations-and-products.md)
-* [Device management](nerves-hub/device-management.md)
 * [HTTP API](nerves-hub/http-api.md)
 * [Device WebSocket](nerves-hub/device-websocket.md)
 

--- a/nerves-hub/device-management.md
+++ b/nerves-hub/device-management.md
@@ -1,8 +1,0 @@
-# Device management
-
-TBD. This section talks about the various device management features of NervesHub and how to enable and use them:
-
-1. Device health and tweaking thresholds
-2. Enabling and using remote IEx consoles
-3. Remote reboot
-

--- a/nerves-hub/managing-organizations-and-products.md
+++ b/nerves-hub/managing-organizations-and-products.md
@@ -1,4 +1,0 @@
-# Managing organizations and products
-
-TBD. This section is intended to talk about organizations, products, and permissions.
-

--- a/nerves-hub/setup/adding-nerveshub-to-your-project.md
+++ b/nerves-hub/setup/adding-nerveshub-to-your-project.md
@@ -6,7 +6,7 @@ The first step is to add [`nerves_hub_link`](https://github.com/nerves-hub/nerve
   defp deps(target) do
     [
       {:nerves_runtime, "~> 0.13"},
-      {:nerves_hub_link, "~> 2.7"},
+      {:nerves_hub_link, "~> 2.12"},
       {:nerves_time, "~> 0.4"},
       ...
     ] ++ system(target)

--- a/nerves-hub/setup/adding-nerveshub-to-your-project.md
+++ b/nerves-hub/setup/adding-nerveshub-to-your-project.md
@@ -5,23 +5,15 @@ The first step is to add [`nerves_hub_link`](https://github.com/nerves-hub/nerve
 ```elixir
   defp deps(target) do
     [
-      {:nerves_runtime, "~> 0.9"},
-      {:nerves_hub_link, "~> 2.0"},
-      {:nerves_hub_cli, "2.0.0-dev"},
-      {:nerves_time, "~> 0.2"},
+      {:nerves_runtime, "~> 0.13"},
+      {:nerves_hub_link, "~> 2.7"},
+      {:nerves_time, "~> 0.4"},
       ...
     ] ++ system(target)
   end
 ```
 
-Next, update your `config.exs` so that the [`nerves_hub_link`](https://github.com/nerves-hub/nerves\_hub\_link) library can help provision devices. Do this by adding `provisioning: :nerves_hub_link` to the `:nerves, :firmware` option like this:
-
-```elixir
-config :nerves, :firmware,
-  provisioning: :nerves_hub_link
-```
-
-Adding this library will start a long-lived websocket connection with NervesHub for communicating device updates.
+Adding `:nerves_hub_link` will start a long-lived websocket connection with NervesHub for communicating device updates.
 
 ## Connection Setup
 
@@ -51,8 +43,8 @@ In some cases you may opt to use your own device signer CA when creating device 
 
 1. Your signer CA must be uploaded to NervesHub. You can do this a couple ways
 
-* From the web UI at `https://www.nerves-hub.org/settings/{YOUR_ORG}/certificates/new`
-* Via CLI with `mix nerves_hub.ca_certificate register /path/to/signer-ca.pem`
+* From the web UI at by visiting your Organization and the tab Certificates.
+* Via CLI with `nh cacert register /path/to/signer-ca.pem`
 
 2. The signer CA must be included in the connection request alongside the NervesHub intermediate CAs. If you're using [`NervesKey`](https://github.com/nerves-hub/nerves\_key), then this is typically handled for you. If managing certificates more manually, it is usually best to read at runtime and appened to the CA list. Here's a basically example of what that step might look like:
 

--- a/nerves-hub/setup/connecting-other-envs.md
+++ b/nerves-hub/setup/connecting-other-envs.md
@@ -3,18 +3,6 @@
 To configure NervesHubLink to talk to your hosted server, the following configuration must be set:
 
 ```elixir
-# The Server CA Certificates need to be provided.
-ca_certs = "/path/to/my-nerves-hub.org/ca_certs"
-
 config :nerves_hub_link,
-  device_api_host: "device.my-nerves-hub.org",
-  device_api_sni: 'device.my-nerves-hub.org',
-  device_api_port: 443,
-  ca_certs: ca_certs
-
-config :nerves_hub_cli, 
-  host: "my-nerves-hub.org",
-  port: 443,
-  server_name_indication: 'my-nerves-hub.org',
-  ca_certs: ca_certs
+  host: "device.my-nerves-hub.org",
 ```

--- a/nerves-hub/setup/deployments.md
+++ b/nerves-hub/setup/deployments.md
@@ -5,7 +5,7 @@
 Deployments associate firmware images to devices. NervesHub won't send firmware to a device until you create a deployment. First find the UUID of the firmware. You can list the firmware on NervesHub by calling:
 
 ```bash
-mix nerves_hub.firmware list
+nh firmware list
 
 Firmwares:
 ------------
@@ -19,7 +19,7 @@ Firmwares:
 In this example we will create a new deployment for our test group using firmware `1cbecdbb-aa7d-5aee-4ba2-864d518417df`.
 
 ```bash
-mix nerves_hub.deployment create
+nh deployment create
 
 NervesHub organization: nerveshub
 Deployment name: qa_deployment
@@ -43,7 +43,7 @@ mix firmware
 We can publish, sign, and deploy firmware in a single command now.
 
 ```bash
-mix nerves_hub.firmware publish --key devkey --deploy qa_deployment
+nh firmware publish --key devkey --deploy qa_deployment
 ```
 
 ## Conditionally applying updates

--- a/nerves-hub/setup/devices.md
+++ b/nerves-hub/setup/devices.md
@@ -5,7 +5,7 @@
 In this example we will create a device with a hardware identifier `1234`. The device will also be tagged with `qa` so we can target it in our deployment group. Device certificates are required for a device to establish a connection with the NervesHub server.
 
 ```bash
-$ mix nerves_hub.device create
+$ nh device create
 
 NervesHub organization: nerveshub
 identifier: 1234
@@ -18,16 +18,16 @@ Finished
 
 If your device has an ATECCx08A module or NervesKey that has been provisioned by a CA/signer certificate known to NervesHub, the device is ready to go. If not using a hardware module to protect the device's private key, create and register a certificate and key pair manually by running:
 
-{% code overflow="wrap" %}
+```bash
+nh device cert create 1234 \
+--signer-key key.pem \
+--signer-cert cert.pem
 ```
-mix nerves_hub.device cert create 1234 --signer-key key.pem --signer-cert cert.pem
-```
-{% endcode %}
 
 NervesHub certificates and hardware identifiers are persisted to the firmware when the firmware is burned to the SD card. To make this process easier, you can call `nerves_hub.device burn IDENTIFIER`. In this example, we are going to burn the firmware and certificates for device `1234` that we created.
 
 ```bash
-mix nerves_hub.device burn 1234
+nh device burn 1234
 ```
 
 Your device will now connect to NervesHub when it boots and establishes an network connection.

--- a/nerves-hub/setup/firmware-signing-keys.md
+++ b/nerves-hub/setup/firmware-signing-keys.md
@@ -7,13 +7,13 @@ Firmware authentication uses [Ed25519 digital signatures](https://en.wikipedia.o
 Start by creating a `devkey` firmware signing key pair:
 
 ```bash
-mix nerves_hub.key create devkey --org my-organisation-name
+nh key create devkey --org my-organisation-name
 ```
 
 On success, you'll see the public key. You can confirm using the NervesHub web interface that the public key exists. Private keys are never sent to the NervesHub server. NervesHub requires valid signatures from known keys on all firmware it distributes. Since this command uploads the public key to NervesHub you are now ready to sign firmware with it.
 
 ```bash
-mix nerves_hub.firmware sign myfirmware.fw --key devkey
+nh firmware sign myfirmware.fw --key devkey
 ```
 
 On authenticating with NervesHub a device will download the available public keys to enable validation of firmware signatures.

--- a/nerves-hub/setup/firmware.md
+++ b/nerves-hub/setup/firmware.md
@@ -11,13 +11,13 @@ mix firmware
 Firmware can only be published if has been signed. You can sign the firmware by running.
 
 ```bash
-mix nerves_hub.firmware sign --key devkey
+nh firmware sign --key devkey
 ```
 
 Firmware can also be signed while publishing:
 
 ```bash
-mix nerves_hub.firmware publish --key devkey
+nh firmware publish --key devkey
 ```
 
 ## Delta Updates

--- a/nerves-hub/setup/nerveshub-products.md
+++ b/nerves-hub/setup/nerveshub-products.md
@@ -18,6 +18,6 @@ For the remainder of this document, though, we will not use the `:name` field an
 Create a new product on NervesHub by running:
 
 ```bash
-mix nerves_hub.product create
+nh product create
 ```
 

--- a/nerves-key/integration-with-nerveshub.md
+++ b/nerves-key/integration-with-nerveshub.md
@@ -33,12 +33,12 @@ Make sure that your Nerves project includes the `:nerves_key` dependence in your
   defp deps do
     [
       # Dependencies for all targets
-      {:nerves, "~> 1.11", runtime: false},
+      {:nerves, "~> 1.14", runtime: false},
       ...
 
       # Dependencies for all targets except :host
-      {:nerves_hub_link, "~> 2.7", targets: @all_targets},
-      {:nerves_key, "~> 1.2", targets: @all_targets},
+      {:nerves_hub_link, "~> 2.12", targets: @all_targets},
+      {:nerves_key, "~> 1.3", targets: @all_targets},
       {:nerves_time, "~> 0.4", targets: @all_targets},
     ]
 ```

--- a/nerves-key/integration-with-nerveshub.md
+++ b/nerves-key/integration-with-nerveshub.md
@@ -8,10 +8,10 @@ description: >-
 
 ## Device registration
 
-Devices must be registered with NervesHub via the commandline tools, web user interface or User API first. You will need the device's manufacturing serial number for this step. If you don't have it, the Quickstart firmware or `NervesKey.manufacturing_sn/1` can retrieve it. From the CLI, run `mix nerves_hub.device create`. Fill in the manufacturing serial number when it asks for an identifier. Fill in the `description` and `tags` fields as you'd like:
+Devices must be registered with NervesHub via the commandline tools, web user interface or User API first. You will need the device's manufacturing serial number for this step. If you don't have it, the Quickstart firmware or `NervesKey.manufacturing_sn/1` can retrieve it. From the CLI, run `nh device create`. Fill in the manufacturing serial number when it asks for an identifier. Fill in the `description` and `tags` fields as you'd like:
 
 ```text
-$ mix nerves_hub.device create
+$ nh device create
 NervesHub server: api.nerves-hub.org:443
 NervesHub organization: your_organization
 identifier: 123456789ABCDE
@@ -22,7 +22,7 @@ Device 123456789ABCDE created
 ```
 
 {% hint style="info" %}
-When registering devices in bulk, we've found that there's usually a convenient hook in the manufacturing process to call `mix nerves_hub.device create` with commandline parameters. A future enhancement to NervesHub will allows you to have NervesHub automatically create devices that present properly signed device certificates and firmware metadata.
+When registering devices in bulk, we've found that there's usually a convenient hook in the manufacturing process to call `nh device create` with commandline parameters. NervesHub also has the JITP method which allows Just-In-Time Provisioning of device information into NervesHub based on what has been provisioned into a NervesKey or certificate.
 {% endhint %}
 
 ### Integration with your Nerves project
@@ -33,13 +33,13 @@ Make sure that your Nerves project includes the `:nerves_key` dependence in your
   defp deps do
     [
       # Dependencies for all targets
-      {:nerves, "~> 1.4", runtime: false},
-      ... 
-      
+      {:nerves, "~> 1.11", runtime: false},
+      ...
+
       # Dependencies for all targets except :host
-      {:nerves_hub, "~> 0.2", targets: @all_targets},
-      {:nerves_key, "~> 0.3", targets: @all_targets},
-      {:nerves_time, "~> 0.2", targets: @all_targets},
+      {:nerves_hub_link, "~> 2.7", targets: @all_targets},
+      {:nerves_key, "~> 1.2", targets: @all_targets},
+      {:nerves_time, "~> 0.4", targets: @all_targets},
     ]
 ```
 

--- a/nerves-key/integration-with-nerveshublink.md
+++ b/nerves-key/integration-with-nerveshublink.md
@@ -42,8 +42,8 @@ You can tell `nerves_hub_link` to read those certificates and key from the chip 
 ```elixir
 def deps() do
   [
-    {:nerves_hub_link, "~> 2.7"},
-    {:nerves_key, "~> 1.2"}
+    {:nerves_hub_link, "~> 2.12"},
+    {:nerves_key, "~> 1.3"}
   ]
 end
 ```

--- a/nerves-key/integration-with-nerveshublink.md
+++ b/nerves-key/integration-with-nerveshublink.md
@@ -12,7 +12,7 @@ Devices must be registered with NervesHub via the commandline tools, web user in
 
 The command-line tools are the easiest for this. Follow [these instructions](/nerves-hub/cli-tools.md) to get them installed.
 
-You will need the device's manufacturing serial number for this step. If you don't have it `NervesKey.manufacturer_sn/1` can retrieve it. From the CLI, run `mix nerves_hub.device create`. Fill in the manufacturing serial number when it asks for an identifier. Fill in the `description` and `tags` fields as you'd like:
+You will need the device's manufacturing serial number for this step. If you don't have it `NervesKey.manufacturer_sn/1` can retrieve it. From the CLI, run `nh device create`. Fill in the manufacturing serial number when it asks for an identifier. Fill in the `description` and `tags` fields as you'd like:
 
 ```text
 $ nh device create
@@ -26,7 +26,7 @@ Device 123456789ABCDE created
 ```
 
 {% hint style="info" %}
-When registering devices in bulk, we've found that there's usually a convenient hook in the manufacturing process to call `mix nerves_hub.device create` with commandline parameters.
+When registering devices in bulk, we've found that there's usually a convenient hook in the manufacturing process to call `nh device create` with commandline parameters.
 {% endhint %}
 
 If you are not using the Signer CA approach you also want to upload a certificate per device. This can be done using:
@@ -50,7 +50,7 @@ end
 
 NervesKey will default to using i2c bus 1 and `:primary` cerificate pair.
 
-NervesHubLink will use the NervesKey library by default if it is available. NervesHubLink itself needs to be configured a bit:
+NervesHubLink will use the NervesKey library by default if it is available. It still needs to be configured a bit:
 
 ```elixir
 config :nerves_hub_link,

--- a/production/index.md
+++ b/production/index.md
@@ -144,8 +144,8 @@ you are targeting.
 In your Nerves project find `mix.exs` and in the function called `deps` add:
 
 ```elixir
-{:nerves_hub_link, "~> 2.7"},
-{:nerves_key, "~> 1.2"}
+{:nerves_hub_link, "~> 2.12"},
+{:nerves_key, "~> 1.3"}
 ```
 
 Now run:

--- a/quickstart/index.md
+++ b/quickstart/index.md
@@ -52,7 +52,7 @@ Shared Secret authentication. Hit the button for creating a new Shared Secret.
 In your Nerves project find `mix.exs` and in the function called `deps` add:
 
 ```elixir
-{:nerves_hub_link, "~> 2.7"},
+{:nerves_hub_link, "~> 2.12"},
 ```
 
 Now run:


### PR DESCRIPTION
This updates version numbers for all dependencies mentioned.

Moved the CLI install instructions to the top to indicate that they should be installed before proceeding with setup.

Updated all uses of the CLI to use the new calling conventions.

Remove inaccurate or outdated information such as suggesting that JITP might exist sometime in the future. It exists now.